### PR TITLE
[] coordinate lookup method with command line support for tile coordinate description

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -27,7 +27,9 @@ Metrics/AbcSize:
 # Offense count: 4
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
-  Max: 209
+  Exclude:
+    - 'lib/CLI/command.rb'
+  Max: 197
 
 # Offense count: 2
 # Configuration parameters: AllowedMethods, AllowedPatterns.

--- a/README.md
+++ b/README.md
@@ -61,10 +61,26 @@ See Command line Usage for full customization, below are some examples. Alter th
 
 # Generate without rendering
 
-```bash
+```irb
 irb(main):001:0> map = Map.new
-...
-irb(main):002:0> map.describe[1][0]
+```
+
+Map can then be manipulated via traditional x,y lookup
+```irb
+map[x, y].to_h
+=>
+{:x=>0,                                                        
+ :y=>1,                                                        
+ :height=>0.29251394359649563,                                 
+ :moist=>0.29100678755603004,                                  
+ :temp=>0.6034041566100443,                                    
+ :biome=>{:name=>"deep_valley", :flora_range=>1, :colour=>"\e[48;5;47m"},
+ :items=>[]}
+```
+or the less intuitative multidimensional lookup (reversed axis):
+
+```irb
+map.tiles[y][x].to_h
 => 
 {:x=>0,                                                        
  :y=>1,                                                        

--- a/README.md
+++ b/README.md
@@ -91,6 +91,20 @@ map.tiles[y][x].to_h
  :items=>[]}
 ```
 
+or from the command line:
+
+```bash
+$ ruby-perlin-2D-map-generator describe coordinates=0,1
+
+{:x=>0,                                                        
+ :y=>1,                                                        
+ :height=>0.29251394359649563,                                 
+ :moist=>0.29100678755603004,                                  
+ :temp=>0.6034041566100443,                                    
+ :biome=>{:name=>"deep_valley", :flora_range=>1, :colour=>"\e[48;5;47m"},
+ :items=>[]}
+```
+
 # Full Command line Usage
 ```bash
 $ ruby-perlin-2D-map-generator --help
@@ -104,8 +118,14 @@ hashes with each tiles information.
 
 Arguments:
   (DESCRIBE | RENDER)  command to run: render prints the map to standard
-                       output using ansi colors, while describe prints each
-                       tiles bionome information in the map.
+                       output using ansi colors. describe prints each tiles
+                       bionome information in the map, can be combined with the
+                       coordinates keyword to print a specific tile.
+                       (permitted: describe, render)
+
+Keywords:
+  COORDINATES=INT_LIST  Used with the describe command, only returns the given
+                        coordinate tile details
 
 Options:
       --elevation=float  Adjust each generated elevation by this percent (0 -
@@ -149,4 +169,7 @@ Examples:
 
   Render with options
     $ ruby-perlin-2D-map-generator render --elevation=-40 --moisture=25 --hs=1
+
+  Describe tile [1, 1]
+    $ ruby-perlin-2D-map-generator describe coordinates=1,1
 ```

--- a/lib/CLI/command.rb
+++ b/lib/CLI/command.rb
@@ -20,14 +20,25 @@ module CLI
 
       example 'Render with options',
               '  $ ruby-perlin-2D-map-generator render --elevation=-40 --moisture=25 --hs=1'
+
+      example 'Describe tile [1, 1]',
+              '  $ ruby-perlin-2D-map-generator describe coordinates=1,1'
     end
 
     argument :command do
       name '(describe | render)'
       arity one
-      validate ->(v) { v.downcase == 'describe' || v.downcase == 'render' }
-      desc 'command to run: render prints the map to standard output using ansi colors, ' \
-           'while describe prints each tiles bionome information in the map.'
+      permit %w[describe render]
+      desc 'command to run: render prints the map to standard output using ansi colors. ' \
+           'describe prints each tiles bionome information in the map, can be combined with ' \
+           'the coordinates keyword to print a specific tile.'
+    end
+
+    keyword :coordinates do
+      arity one
+      convert :int_list
+      validate ->(v) { v >= 0 }
+      desc 'Used with the describe command, only returns the given coordinate tile details'
     end
 
     option :height_seed do
@@ -255,7 +266,7 @@ module CLI
       ))
       case params[:command]
       when 'render' then map.render
-      when 'describe' then puts map.describe
+      when 'describe' then puts(!params[:coordinates].nil? ? map[params[:coordinates][0], params[:coordinates][1]].to_h : map.describe)
       end
     end
 

--- a/lib/map.rb
+++ b/lib/map.rb
@@ -23,7 +23,7 @@ class Map
 
   # rubocop:disable Naming/MethodParameterName:
   def [](x, y)
-    raise ArgumentError, 'coordinates out of bounds' if y >= tiles.size || x >= tiles[y].size
+    raise ArgumentError, 'coordinates out of bounds' if y.nil? || y >= tiles.size || x.nil? || x >= tiles[y].size
 
     tiles[y][x]
   end

--- a/lib/map.rb
+++ b/lib/map.rb
@@ -21,6 +21,14 @@ class Map
     end
   end
 
+  # rubocop:disable Naming/MethodParameterName:
+  def [](x, y)
+    raise ArgumentError, 'coordinates out of bounds' if y >= tiles.size || x >= tiles[y].size
+
+    tiles[y][x]
+  end
+  # rubocop:enable Naming/MethodParameterName:
+
   def tiles
     @tiles ||= MapTileGenerator.new(map: self).generate
   end

--- a/test/map_test.rb
+++ b/test/map_test.rb
@@ -57,6 +57,33 @@ class MapTest < Minitest::Test
     assert_equal "00011011\n\n", output
   end
 
+  def test_index_lookup
+    mock_one = mock('Tile1')
+    mock_two = mock('Tile2')
+    mock_three = mock('Tile3')
+    mock_four = mock('Tile4')
+
+    tiles = [[mock_one, mock_two], [mock_three, mock_four]]
+
+    map = Map.new
+    map.expects(:tiles).at_least_once.returns(tiles)
+
+    assert_equal mock_one, map[0, 0]
+    assert_equal mock_three, map[0, 1]
+    assert_equal mock_two, map[1, 0]
+    assert_equal mock_four, map[1, 1]
+  end
+
+  def test_index_out_of_bound_raises_error
+    tiles = [[mock('Tile1'), mock('Tile2')], [mock('Tile3'), mock('Tile4')]]
+    map = Map.new
+    map.expects(:tiles).returns(tiles)
+
+    assert_raises ArgumentError, 'coordinates out of bounds' do
+      map[1, 2]
+    end
+  end
+
   private
 
   def capture_output

--- a/test/map_test.rb
+++ b/test/map_test.rb
@@ -77,10 +77,18 @@ class MapTest < Minitest::Test
   def test_index_out_of_bound_raises_error
     tiles = [[mock('Tile1'), mock('Tile2')], [mock('Tile3'), mock('Tile4')]]
     map = Map.new
-    map.expects(:tiles).returns(tiles)
+    map.expects(:tiles).at_least_once.returns(tiles)
 
     assert_raises ArgumentError, 'coordinates out of bounds' do
       map[1, 2]
+    end
+
+    assert_raises ArgumentError, 'coordinates out of bounds' do
+      map[nil, 2]
+    end
+
+    assert_raises ArgumentError, 'coordinates out of bounds' do
+      map[1, nil]
     end
   end
 


### PR DESCRIPTION
interacting with a maps tiles required using the unintuitive reverse axis lookup through the multidimensional array, ie `map.tiles[y][x]` , instead the new method enables `map[x, y]`

add command line support to describe specific tile via provided coordinates